### PR TITLE
IAX2 trunk discovery fix

### DIFF
--- a/asterisk/zabbix_agentd.d/scripts/asterisk.sh
+++ b/asterisk/zabbix_agentd.d/scripts/asterisk.sh
@@ -60,7 +60,14 @@ convert_pjsip_registrations_to_json() {
 }
 
 discovery.iax2.registry() {
-  REGISTRY="$($sudo asterisk -r -x "iax2 show registry" | grep -v -e "^Host" -e "IAX2 registrations")"
+  REGISTRY="$($sudo asterisk -rx "iax2 show registry" | grep -q 'No such command')"
+  
+  if [ $? == 0 ]; then ## IAX2 is not installed
+    REGISTRY=""
+  else
+    REGISTRY="$($sudo asterisk -r -x "iax2 show registry" | grep -v -e "^Host" -e "IAX2 registrations")"
+    fi
+  
   convert_registrations_to_json
 }
 


### PR DESCRIPTION
This should fix that issue with the IAX2 modules not being loaded in ugoviti/zabbix-templates#4